### PR TITLE
Fix radians and degrees conversion macros

### DIFF
--- a/firmware/TinyGPS++.cpp
+++ b/firmware/TinyGPS++.cpp
@@ -32,10 +32,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define _GPGGAterm   "GPGGA"
 
 // Converts degrees to radians.
-#define radians(angleDegrees) (angleDegrees * M_PI / 180.0)
+#define radians(angleDegrees) ((angleDegrees) * M_PI / 180.0)
  
 // Converts radians to degrees.
-#define degrees(angleRadians) (angleRadians * 180.0 / M_PI)
+#define degrees(angleRadians) ((angleRadians) * 180.0 / M_PI)
 
 #define TWO_PI 6.283185307179586476925286766559
 #define sq(x) ((x)*(x))


### PR DESCRIPTION
There's a bug in the `distanceBetween` and `courseTo` because `radians` doesn't include its argument in parentheses.

When doing `radians(long1-long2)` the macro was expanded to `long1-long2*M_PI/180.0`.
