### PR TITLE
calculate distance with one known point

### DIFF
--- a/firmware/TinyGPS++.cpp
+++ b/firmware/TinyGPS++.cpp
@@ -374,6 +374,12 @@ double TinyGPSLocation::lng()
    return rawLngData.negative ? -ret : ret;
 }
 
+double TinyGPSLocation::distanceBetween(double lat1, double long1)
+{
+    return TinyGPSPlus::distanceBetween(double lat1, double long1, lat(), lng());
+}
+
+
 void TinyGPSDate::commit()
 {
    date = newDate;


### PR DESCRIPTION
First, apologies because I'm not equipped to test this, nor am I sure it's correct, but I hope it's close.

The idea is to create a helper method for gps.location.distanceBetween(). That way the object's location can be used instead of needing to pass it back in:

```
gps.distanceBetween(otherLat, otherLng, gps.location.lat(), gps.location.lng())
```

Here's the helper method:

```
gps.location.distanceBetween(otherLat, otherLng)
```
